### PR TITLE
change 'Accepts' to specific type in request header

### DIFF
--- a/app/modules/EndPointService.js
+++ b/app/modules/EndPointService.js
@@ -23,6 +23,7 @@
 
             options.timeout = cancelPendingRequest.promise;
             options.params = options.data;
+            options.headers = { 'Accept' : 'application/sparql-results+json' };
             delete (options.data);
 
             $http(options).success(httpRequest.resolve).error(httpRequest.reject);


### PR DESCRIPTION
Short explanation: When using the AngularJS httpProvider, the
default header for requests contains (see [1]):

```
Accept: application/json, text/plain, * / *
```

Note that there are no quality values. Some servers will not
respect the order of the MIME types and will answer with any
type of the highest quality.

This wouldn't be too bad if only the VSB (or rather jassa)
could digest text/plain SPARQL results. Unfortunately,
it cannot and throws an error. This commit fixes this behaviour.
1. https://docs.angularjs.org/api/ng/service/$http
